### PR TITLE
Use paths relative to the script instead of cwd

### DIFF
--- a/clang/utils/generate_unsupported_in_drivermode.py
+++ b/clang/utils/generate_unsupported_in_drivermode.py
@@ -504,21 +504,12 @@ for unsupported_pair in unsupported_sequence:
         unsupported_pair.prefix + unsupported_pair.option_name
     )
 
-args.general_test_path = (
-    "../test/Driver/unsupported_in_drivermode.c"
-    if not args.general_test_path
-    else args.general_test_path
-)
-args.flang_test_path = (
-    "../test/Driver/flang/unsupported_in_flang.f90"
-    if not args.flang_test_path
-    else args.flang_test_path
-)
-args.flang_fc1_test_path = (
-    "../../flang/test/Driver/unsupported_in_flang_fc1.f90"
-    if not args.flang_fc1_test_path
-    else args.flang_fc1_test_path
-)
+args.general_test_path = args.general_test_path or os.path.join(
+    os.path.dirname(__file__), "../test/Driver/unsupported_in_drivermode.c")
+args.flang_test_path = args.flang_test_path or os.path.join(
+    os.path.dirname(__file__), "../test/Driver/flang/unsupported_in_flang.f90")
+args.flang_fc1_test_path = args.flang_fc1_test_path or os.path.join(
+    os.path.dirname(__file__), "../../flang/test/Driver/unsupported_in_flang_fc1.f90")
 
 write_lit_test(
     args.general_test_path,


### PR DESCRIPTION
The defaults for `--{general,flang,flang-fc1}-test-path` should be relative to the script, not the current working directory when executing the script. Allows the script to be run from a different directory, instead of assuming `clang/utils`.